### PR TITLE
Disable emacs lock files.

### DIFF
--- a/emacs/emacs.d/customac/customac-editor.el
+++ b/emacs/emacs.d/customac/customac-editor.el
@@ -39,7 +39,8 @@
       save-place-file (concat user-emacs-directory "places")
       backup-directory-alist `(("." . ,(concat user-emacs-directory
 					       "backups")))
-      auto-save-file-name-transforms `((".*" ,temporary-file-directory t)))
+      auto-save-file-name-transforms `((".*" ,temporary-file-directory t))
+      create-lockfiles nil)
 
 (setq global-auto-revert-non-file-buffers t)
 (setq auto-revert-verbose nil)


### PR DESCRIPTION
Emacs generates lockfiles when you modify a file (`foo.clj` -> `.#foo.clj)`.
This causes problems with clojure cider since reloading namespaces will
pickup any files that end with .clj (including the symlink lock). If
this happens to get loaded, all subsequent reloads will fail since the
contents of the symlink is empty (invalid when assuming loading a ns in
clojure). But the ns exists within the repl, ensuring that it attempts
to reload the namespace.

Emacs uses this to prevent simutaneous emacs users from editing the same
file. This isn't necessary since we're using a server on the same
machine, and never have two different users editing the same file.

Since the lock file cannot be renamed and we don't have any benefit for
locking files we're modifying, it's easier to disable this feature.

Reference:
http://www.gnu.org/software/emacs/manual/html_node/emacs/Interlocking.html