### PR TITLE
Don't autofocus test report buffer

### DIFF
--- a/emacs/emacs.d/customac/customac-clojure.el
+++ b/emacs/emacs.d/customac/customac-clojure.el
@@ -33,6 +33,7 @@
 (setq nrepl-log-messages t)
 (setq nrepl-hide-special-buffers nil)
 (setq cider-prefer-local-resources t)
+(setq cider-auto-select-test-report-buffer nil)
 
 (smartparens-global-mode t)
 (setq sp-base-key-bindings 'paredit)


### PR DESCRIPTION
This configuration value prevents the cursor focus from switching to the test report buffer.